### PR TITLE
Fix hinmil substitutions

### DIFF
--- a/hinmil/app/Main.hs
+++ b/hinmil/app/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Lib
+import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty(..))
 
 printUResult :: Either UnificationFailure Substitutions -> String
@@ -69,6 +70,7 @@ ex5Term1 =
   let
     t1 = TyApp "Vector" (TyVar "A" :| [])
     t2 = TyVar "A"
+  -- Either[Vector[A], A]
   in TyApp "Either" (t1 :| [t2])
 
 ex5Term2 :: Term
@@ -76,12 +78,27 @@ ex5Term2 =
   let
     t1 = TyVar "B"
     t2 = TyApp "Maybe" (TyVar "C" :| [])
+  -- Either[B,Maybe[C]]
   in TyApp "Either" (t1 :| [t2])
 
 -- {Maybe[C]/A, Vector[Maybe[C]]/B}
 
 ex5 :: Either UnificationFailure Substitutions
 ex5 = unify ex5Term1 ex5Term2
+
+
+compareSubstituted :: Term -> Term -> Substitutions -> String
+compareSubstituted term1 term2 ss
+  | subs ss term1 == subs ss term2 = "Unified!"
+  | otherwise = intercalate " "
+      [ "left: "
+      , printTerm $ subs ss term1
+      , "right:"
+      , printTerm $ subs ss term2
+      , "MGU:"
+      , printSubsts ss
+      ]
+
 
 main :: IO ()
 main = do
@@ -90,3 +107,4 @@ main = do
   putStrLn $ printUResult ex3
   putStrLn $ printUResult ex4
   putStrLn $ printUResult ex5
+  putStrLn $ either printUFailure (compareSubstituted ex5Term1 ex5Term2) ex5

--- a/hinmil/src/Lib.hs
+++ b/hinmil/src/Lib.hs
@@ -4,6 +4,7 @@ module Lib
   , Substitutions, sub1, printSubsts
   , UnificationFailure, printUFailure
   , unify
+  , subs
   ) where
 
 import Data.List.NonEmpty (NonEmpty(..), toList)
@@ -12,7 +13,7 @@ import Control.Monad (join)
 
 type Name = String
 
-data Term = TyVar Name | TyApp Name (NonEmpty Term)
+data Term = TyVar Name | TyApp Name (NonEmpty Term) deriving Eq
 
 printTerm :: Term -> String
 printTerm (TyVar name) = name
@@ -36,16 +37,14 @@ sub1 s = Substs [s]
 -- | Substitutions closer to the head get precedence over ones closer to the
 -- | tail.
 subs :: Substitutions -> Term -> Term
--- If we have no substitutions, return the same term.
-subs (Substs []) term = term
 -- If we have hit a leaf of our type AST, to wit, a type variable, then iterate
 -- through the substitutions, looking for a match on its name. If found,
 -- substitute in the corresponding term, and short-circuit.
-subs (Substs (Subst t1 v1 : ss)) term@(TyVar name) =
-  if name == v1 then t1 else subs (Substs ss) term
--- If we have hit a type application, apply all the substitutions to all the
--- arguments of the type operator.
-subs s (TyApp name args) = TyApp name $ fmap (subs s) args
+subs (Substs ss) term = foldr replace term ss where
+  replace :: Substitution -> Term -> Term
+  replace (Subst t1 v1) t@(TyVar name) =
+    if name == v1 then t1 else t
+  replace s (TyApp name args) = TyApp name $ fmap (subs $ Substs [s]) args
 
 instance Semigroup Substitution where
   -- Substitutions on the right are applied to the terms in the substitutions on
@@ -95,7 +94,7 @@ unify = iter (Substs []) where
     substitutions' <- iter (Substs []) (subs substs arg1) (subs substs arg2)
     case (arg1s, arg2s) of
       ([], []) ->
-        let Substs ss = substitutions'
+        let Substs ss = substitutions' <> substs
         in Right $ Substs $ reverse ss
       (arg1' : arg1s', arg2' : arg2s') ->
         let ss = substitutions' <> substs


### PR DESCRIPTION
Mappings were being dropped on multi-arg type applications
Substitutions needed to be applied right to left.